### PR TITLE
apply pre first and then post middlewares

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "promise",
     "promises"
   ],
-  "engines": {
-    "node": "6.2.0"
-  },
   "author": "Brandon Keown",
   "license": "MIT",
   "bugs": {

--- a/src/middleware/combinators.js
+++ b/src/middleware/combinators.js
@@ -6,7 +6,7 @@ const Promise = require("bluebird");
  * We can apply a stack of middlewares i.e. [Middleware] by reducing from the right with function application using
  * the base app as the seed
  */
-const applyStack = R.curry((stack, app) => R.reduceRight((app, middle) => middle(app), app, stack));
+const applyStack = R.curry((stack, app) => R.reduce((app, middle) => middle(app), app, stack));
 
 /**
  * Lifts a function of Context -> Promise Context to a middleware function (App -> App). Pre is a processor of contexts,


### PR DESCRIPTION
I've tried this, and maybe it's the new Ramda, maybe it's the new node, dunno, but one of the tests was failing, so looking at it closer I discovered that the applyStack was applying postMiddleware first, and then preMiddlewares. Atm I can't tell if this was the intent and the tests should have been rewritten as [postMiddle, preMiddle]. :)